### PR TITLE
Updated README for Flatpak Support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,11 @@ sudo ./install.sh
 
 Then apply this theme with GNOME Tweaks or using your desktop's appearance settings
 
+# Flatpak install
+```
+flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+flatpak install flathub org.gtk.Gtk3theme.Adementary
+```
 # Reporting bugs/Add suggestions
 report it via "Issues" tab, Pull request for bugfixes and features also accepted.
 for suggestion about design add [design] tag, for DEs/gtk+ app theming/etc. support, add [feature request] tag


### PR DESCRIPTION
Hi hrdwrrsk,

I've managed to get your theme onto Flathub repositories so it can work with Flatpak applications. Here is the theme: https://github.com/flathub/org.gtk.Gtk3theme.Adementary

If you want to try it, here are the commands:
```
flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
flatpak install flathub org.gtk.Gtk3theme.Adementary
```
Since the package successfully made it to Flathub, I've updated the README for your repository by adding a "Flatpak installation" subsection. Feel free to edit it or let me know if you have any issues/concerns with Flatpak support.

Thanks
Berk
